### PR TITLE
Add support for F13-F24

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -271,6 +271,18 @@ pub enum Code {
     Application,
     Power,
     NumPadEqual,
+    F13,
+    F14,
+    F15,
+    F16,
+    F17,
+    F18,
+    F19,
+    F20,
+    F21,
+    F22,
+    F23,
+    F24,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, DeserializeFromStr)]


### PR DESCRIPTION
As simple as it gets :)

Tested on Linux (X11) and Windows using: https://www.toptal.com/developers/keycode

Reference: https://usb.org/sites/default/files/hut1_3_0.pdf

Nice tool by the way! Tested on my 3x2 (1 knob) and it works perfectly.