### PR TITLE
options: allow using hex for VID, PID

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -7,14 +7,23 @@ pub struct Options {
     #[command(subcommand)]
     pub command: Command,
 
-    #[arg(long, default_value_t=VENDOR_ID)]
+    #[arg(long, default_value_t=VENDOR_ID, value_parser=hex_or_decimal)]
     pub vendor_id: u16,
 
-    #[arg(long, default_value_t=PRODUCT_ID)]
+    #[arg(long, default_value_t=PRODUCT_ID, value_parser=hex_or_decimal)]
     pub product_id: u16,
 
     #[arg(long, value_parser=parse_address)]
     pub address: Option<(u8, u8)>,
+}
+
+pub fn hex_or_decimal(s: &str) -> Result<u16, String>
+{
+    if s.to_ascii_lowercase().starts_with("0x") {
+        u16::from_str_radix(&s[2..], 16)
+    } else {
+        u16::from_str_radix(s, 10)
+    }.map_err(|e| format!("{e}"))
 }
 
 fn parse_address(s: &str) -> std::result::Result<(u8, u8), nom::error::Error<String>> {


### PR DESCRIPTION
I usually use hex values for specifying the VID and PID of a USB product :-).

I didn't create any test for the function `hex_or_decimal`, but I guess is quite straight forward :-)