### PR TITLE
Polish the README & example-mapping.yaml and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2023 Mikhail Trishchenkov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ ch57x-keyboard-tool [OPTIONS] <COMMAND>
 | `--product-id <PRODUCT_ID>` | Product ID of the keyboard | Default: `34960` |
 | `--address <ADDRESS>`       | Address of the keyboard    |                  |
 
-
 ### Validate the config file
 
 ```shell
@@ -136,22 +135,19 @@ If you want any automation, use third-party automation tools, like [BetterTouchT
 
 ### Number of layers
 
-All keyboards I've seen have three layer (three keys configuration which
-may be switched). However I've been told there are keyboards without
-layer switch. If so, just keep single layer in configuration file and you
-are done.
+All keyboards I have seen have three layers (three key configurations which may be switched).  
+However, I have been told there are keyboards without layer switch.
+If so, just keep a single layer in the configuration file and you are done.
 
 ### Custom keyboard layouts
 
-If you use custom keyboard layout, like Dvorak, note that what you
-write in configuration is in fact scan code of keyboard key and not
-character that will be produced.
+If you use a custom keyboard layout, like Dvorak, note that you will need to write the keyboard key's scan code in the configuration file (not the character that is produced).
 
-So use QWERTY-letter of keyboard key you want to press.
+So use the QWERTY letter of the keyboard key you want to press.
 
 ### 3x1 keys + 1 knob keyboard limitations
 
-This modification does support key modifiers (like ctrl-, alt-) for the first key in sequence only.
+This modification does support key modifiers (like `ctrl-`, `alt-`, and `cmd-`) for the first key in sequence only.
 
 So you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
 

--- a/README.md
+++ b/README.md
@@ -4,36 +4,37 @@
 
 ## What is this?
 
-This is an utility for programming small keyboards like this one:
+This is a utility for programming small keyboards like this one:
 
 ![Picture of keyboard-12-2](doc/keyboard-12-2.png)
 
-Such keyboards are popular on AliExpress and seller usually sends software
-for programming, but it:
-* requires Windows,
-* is very ugly and inconvenient,
+Such macro keyboards are popular on AliExpress and sellers usually send software for programming, but it:
+* requires Windows
+* is very ugly and inconvenient
 * can only program one key at a time
 * don't expose all keyboard features
 
-There are several modifications of such keyboards with different number of
-buttons and knobs ([see some photos](#photos)) and with/without Bluetooth.
+There are several modifications of such keyboards with different numbers of buttons and knobs (See the [photos of supported keyboards](#photos-of-supported-keyboards)) and with/without Bluetooth.
 
-Both wired and wireless keyboards are supported, however programming
-is possible though wire only in both cases!
+Both wired and wireless keyboards are supported.  
+⚠️ However, the keyboard must be connected to the computer with the USB cable when programming it.
 
-Utility was reported to work with:
+### Supported Keyboards
+
+This utility was reported to work with:
 * 3×4 with 2 knobs (Bluetooth version)
 * 3×3 with 2 knobs
 * 3x2 with 1 knob
 * 3x1 with 1 knob (but [read about it's limitations](#3x1-keys--1-knob-keyboard-limitations))
 
-All these keyboards share same vendor/product IDs: 1189:8890 (hexadecimal).
+All these keyboards share the same vendor/product IDs: `1189:8890` (hexadecimal).
 It is possible to override used vendor/product ID, but it is usually not needed.
 Use it only if you find same-looking keyboard with other vendor/product ID,
 I haven't seen such.
 
-**Ability to override vendor/product ID doesn't mean that you can use
-this software for programming arbitrary keyboards!**
+Refer to the [Supported Macro Keyboards](#supported-macro-keyboards) section for more details.
+
+**⚠️ Ability to override vendor/product ID doesn't mean that you can use this software for programming arbitrary keyboards!**
 
 ## How to get it?
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are several modifications of such keyboards with different numbers of butt
 Both wired and wireless keyboards are supported.  
 ⚠️ However, the keyboard must be connected to the computer with the USB cable when programming it.
 
-### Supported Keyboards
+### Supported keyboards
 
 This utility was reported to work with:
 * 3×4 with 2 knobs (Bluetooth version)
@@ -143,7 +143,7 @@ So you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
 
 When reporting an issue, please include diagnostics such as the list of attached USB devices and the output of the `keyboard` and `mouse` monitoring tools.
 
-### How to Find and List Connected USB Devices
+### How to find and list connected usb devices
 
 #### macOS
 
@@ -189,13 +189,13 @@ cd mouse
 python3 -m mouse
 ```
 
-## Supported Macro Keyboards
+## Supported macro keyboards
 
 * Product ID: 0x8890
     * Vendor ID: 0x1189  (Trisat Industrial Co., Ltd.)
     * [amazon.co.jp/dp/B0CF5L8HP3](https://www.amazon.co.jp/dp/B0CF5L8HP3)
 
-### Photos of Supported Keyboards
+### Photos of supported keyboards
 
 | 3x2 with 1 knob                       | 3x1 with 1 knob                       | 3×3 with 2 knobs                        |
 | ------------------------------------- | ------------------------------------- | --------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ So you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
 
 ## Diagnostics
 
-If you have any troubles using this software, please provide diagnostics.
+When reporting an issue, please include diagnostics such as the list of attached USB devices and the output of the `keyboard` and `mouse` monitoring tools.
 
 ### How to Find and List Connected USB Devices
 
@@ -147,7 +147,7 @@ Get-PnpDevice | Where-Object { $_.Class -eq 'USB' } | Format-Table Name, DeviceI
 
 ### Monitoring generated keyboard and mouse events
 
-Most simple (and cross-platform) way I've found is using `keyboard` and `mouse` Python modules.
+The most simple (and cross-platform) way I have found is using `keyboard` and `mouse` Python modules.
 
 Monitoring keyboard:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ You can also change LED configuration, if you keyboard supports it:
 
     ./ch57x-keyboard-tool led 1
 
+## Windows / PowerShell
+
+Use `Get-Content` for input redireciton:
+
+    Get-Content your-config.yaml | ./ch57x-keyboard-tool validate
+
 ## Automation
 
 The frequent question is "How to run script / emulate several keys / … on key press?"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Use 'sudo' if you get 'Access denied (insufficient permissions)':
 sudo ./ch57x-keyboard-tool upload < your-config.yaml
 ```
 
-### Change led configuration
+### Change LED configuration
 
 If your keyboard supports it, you can change the LED configuration:
 
@@ -146,7 +146,7 @@ So you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
 
 When reporting an issue, please include diagnostics such as the list of attached USB devices and the output of the `keyboard` and `mouse` monitoring tools.
 
-### How to find and list connected usb devices
+### How to find and list connected USB devices
 
 #### macOS
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ cd mouse
 python3 -m mouse
 ```
 
+## Supported Macro Keyboards
+
+* Product ID: 0x8890
+    * Vendor ID: 0x1189  (Trisat Industrial Co., Ltd.)
+    * [amazon.co.jp/dp/B0CF5L8HP3](https://www.amazon.co.jp/dp/B0CF5L8HP3)
+
 ### Photos of Supported Keyboards
 
 | 3x2 with 1 knob                       | 3x1 with 1 knob                       | 3×3 with 2 knobs                        |

--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ This utility has been reported to work with:
 * 3x1 with 1 knob with [limitations](#3x1-keys--1-knob-keyboard-limitations)
 
 All these keyboards share the same vendor/product IDs: `1189:8890` (hexadecimal).
-It is possible to override used vendor/product ID, but it is usually unnecessary.
-Use it only if you find the same-looking keyboard with other vendor/product ID,
-I haven't seen such.
+It is possible to override the used vendor/product ID, but it is usually unnecessary.
+Use this utility on similar-looking keyboard with a different vendor/product ID.
 
 For more details, refer to the [Supported Macro Keyboards](#supported-macro-keyboards) section.
 

--- a/README.md
+++ b/README.md
@@ -52,22 +52,32 @@ Download the latest release from [GitHub releases](https://github.com/kriomant/c
     * Windows: download and run [rustup-init.exe](https://win.rustup.rs/)
 1. Execute `cargo install ch57x-keyboard-tool`.
 
-## How to use?
+## Usage
 
-**Note**: on Windows you need to install [USBDK](https://github.com/daynix/UsbDk/releases) first.
+**Note**: Windows users need to install [USBDK](https://github.com/daynix/UsbDk/releases) first.
 
-Now create you own config from provided *example-mapping.yaml*. Example
-config has extensive documentation and examples inside.
+1. Connect the keyboard to the computer with the USB cable.
+1. Create a configuration file based on the provided [example-mapping.yaml](example-mapping.yaml).
+    * Example config has extensive documentation and examples inside.
+1. Validate the configuration file.
+1. Upload the configuration to the keyboard.
+1. Done! 🎉
 
-You can validate config:
+### List all supported modifiers and key names
+
+Use 'show-keys' command to list all supported modifiers and key names.
+
+```shell
+./ch57x-keyboard-tool show-keys
+```
+
+### Validate the config file
 
 ```shell
 ./ch57x-keyboard-tool validate < your-config.yaml
 ```
 
-Use 'show-keys' command to list all supported modifier and key names.
-
-Finally, upload config to keyboard:
+### Upload the config to the keyboard
 
 ```shell
 ./ch57x-keyboard-tool upload < your-config.yaml
@@ -75,9 +85,13 @@ Finally, upload config to keyboard:
 
 Use 'sudo' if you get 'Access denied (insufficient permissions)':
 
-    sudo ./ch57x-keyboard-tool upload < your-config.yaml
+```shell
+sudo ./ch57x-keyboard-tool upload < your-config.yaml
+```
 
-You can also change LED configuration, if you keyboard supports it:
+### Change led configuration
+
+If your keyboard supports it, you can change the LED configuration:
 
 ```shell
 ./ch57x-keyboard-tool led 1
@@ -85,9 +99,11 @@ You can also change LED configuration, if you keyboard supports it:
 
 ### Windows / PowerShell
 
-Use `Get-Content` for input redireciton:
+Use `Get-Content` for input redirection:
 
-    Get-Content your-config.yaml | ./ch57x-keyboard-tool validate
+```shell
+Get-Content your-config.yaml | ./ch57x-keyboard-tool validate
+```
 
 ### Automation
 

--- a/README.md
+++ b/README.md
@@ -119,21 +119,31 @@ So you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
 
 If you have any troubles using this software, please provide diagnostics.
 
-### Getting list of attached USB devices
+### How to Find and List Connected USB Devices
 
-#### MacOS
+#### macOS
 
-
-    ioreg -w0 -l -p IOUSB
+```shell
+system_profiler SPUSBDataType
+```
 
 or
 
-    system_profiler SPUSBDataType
+```shell
+ioreg -w0 -l -p IOUSB
+```
 
 #### Linux
 
+```shell
+lsusb -v
+```
 
-    lsusb -v
+#### Windows
+
+```powershell
+Get-PnpDevice | Where-Object { $_.Class -eq 'USB' } | Format-Table Name, DeviceID, Manufacturer, Status, Description -AutoSize
+```
 
 ### Monitoring generated keyboard and mouse events
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ This modification does support key modifiers (like ctrl-, alt-) for the first ke
 
 So you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
 
+### macOS vs Windows keyboard keys
+
+Friendly reminder that some keys have different names on macOS and Windows.  
+Make sure to use the correct key names in your configuration file.
+
+| Key Name          | macOS Key | Windows Key |
+| ----------------- | --------- | ----------- |
+| Command / Windows | `cmd`     | `win`       |
+| Option / Alt      | `cmd`     | `alt`       |
+
 ## Diagnostics
 
 When reporting an issue, please include diagnostics such as the list of attached USB devices and the output of the `keyboard` and `mouse` monitoring tools.

--- a/README.md
+++ b/README.md
@@ -58,18 +58,31 @@ Download the latest release from [GitHub releases](https://github.com/kriomant/c
 
 1. Connect the keyboard to the computer with the USB cable.
 1. Create a configuration file based on the provided [example-mapping.yaml](example-mapping.yaml).
-    * Example config has extensive documentation and examples inside.
+    * The example config file has extensive documentation inside.
 1. Validate the configuration file.
 1. Upload the configuration to the keyboard.
 1. Done! 🎉
 
-### List all supported modifiers and key names
-
-Use 'show-keys' command to list all supported modifiers and key names.
+### Commands and options
 
 ```shell
-./ch57x-keyboard-tool show-keys
+ch57x-keyboard-tool [OPTIONS] <COMMAND>
 ```
+
+| Command                | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| `show-keys`            | Display a list of all supported keys and modifiers        |
+| `validate`             | Validate key mappings config on stdin                     |
+| `upload`               | Upload key mappings from stdin to device                  |
+| `led`                  | Select LED backlight mode                                 |
+| `help`, `-h`, `--help` | Print this message or the help of the given subcommand(s) |
+
+| Option                      | Description                | Notes            |
+| --------------------------- | -------------------------- | ---------------- |
+| `--vendor-id <VENDOR_ID>`   | Vendor ID of the keyboard  | Default: `4489`  |
+| `--product-id <PRODUCT_ID>` | Product ID of the keyboard | Default: `34960` |
+| `--address <ADDRESS>`       | Address of the keyboard    |                  |
+
 
 ### Validate the config file
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * [What is this?](#what-is-this)
     * [Supported keyboards](#supported-keyboards)
 * [Installation](#installation)
-    * [Get prebuilt release](#get-prebuilt-release)
+    * [Prebuilt release](#prebuilt-release)
     * [Build it yourself](#build-it-yourself)
 * [Usage](#usage)
     * [Commands and options](#commands-and-options)
@@ -32,28 +32,28 @@
 
 ## What is this?
 
-This is a utility for programming small keyboards like this one:
+This keyboard configuration utility is for programming small keyboards, such as the one shown below:
 
 ![Picture of keyboard-12-2](doc/keyboard-12-2.png)
 
 Such macro keyboards are popular on AliExpress, and sellers often include software for programming, but:
-* requires Windows
-* is very ugly and inconvenient
-* can only program one key at a time
-* do not expose all keyboard features
+* It requires Windows
+* It is very ugly and inconvenient
+* It can only program one key at a time
+* It does not expose all keyboard features
 
-There are several modifications of such keyboards with different numbers of buttons and knobs (See the [photos of supported keyboards](#photos-of-supported-keyboards)) and with/without Bluetooth.
+There are several modifications of such keyboards with different numbers of buttons and knobs (see the [photos of supported keyboards](#photos-of-supported-keyboards)) and with/without Bluetooth.
 
 Both wired and wireless keyboards are supported.  
-⚠️ However, the keyboard must be connected to the computer with the USB cable when programming.
+⚠️ However, the keyboard must be connected to the computer with a USB cable when programming.
 
 ### Supported keyboards
 
-This utility was reported to work with:
+This utility has been reported to work with:
 * 3×4 with 2 knobs (Bluetooth version)
 * 3×3 with 2 knobs
 * 3x2 with 1 knob
-* 3x1 with 1 knob with [limitations](#3x1-keys--1-knob-keyboard-limitations))
+* 3x1 with 1 knob with [limitations](#3x1-keys--1-knob-keyboard-limitations)
 
 All these keyboards share the same vendor/product IDs: `1189:8890` (hexadecimal).
 It is possible to override used vendor/product ID, but it is usually unnecessary.
@@ -62,34 +62,34 @@ I haven't seen such.
 
 For more details, refer to the [Supported Macro Keyboards](#supported-macro-keyboards) section.
 
-**⚠️ Ability to override vendor/product ID doesn't mean that you can use this software for programming arbitrary keyboards!**
+**⚠️ The ability to override the vendor/product ID does not mean that you can use this utility to program arbitrary keyboards!**
 
 ## Installation
 
-There are two ways to download the keyboard utility: prebuilt release or build it yourself.
+There are two ways to download the keyboard utility: getting a prebuilt release or building it yourself.
 
-### Get the prebuilt release
+### Prebuilt release
 
-Simply download the [latest release from GitHub](https://github.com/kriomant/ch57x-keyboard-tool/releases)
+Simply download the [latest release from GitHub](https://github.com/kriomant/ch57x-keyboard-tool/releases).
 
 ### Build it yourself
 
-1. Install the *cargo* utility using [rustup](https://rustup.rs/)
+1. Install the *cargo* utility using [rustup](https://rustup.rs/):
     * Brew: `brew install rustup-init && rustup-init`
     * Linux: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-    * Windows: download and run [rustup-init.exe](https://win.rustup.rs/)
-1. Execute `cargo install ch57x-keyboard-tool`.
+    * Windows: Download and run [rustup-init.exe](https://win.rustup.rs/)
+2. Execute `cargo install ch57x-keyboard-tool`.
 
 ## Usage
 
 **Note**: Windows users need to install [USBDK](https://github.com/daynix/UsbDk/releases) first.
 
-1. Connect the keyboard to the computer with the USB cable.
-1. Create a configuration file based on the provided [example-mapping.yaml](example-mapping.yaml).
+1. Connect the keyboard to the computer with a USB cable.
+2. Create a configuration file based on the provided [example-mapping.yaml](example-mapping.yaml).
     * The example config file has extensive documentation inside.
-1. Validate the configuration file.
-1. Upload the configuration to the keyboard.
-1. Done! 🎉
+3. Validate the configuration file.
+4. Upload the configuration to the keyboard.
+5. Done! 🎉
 
 ### Commands and options
 
@@ -97,19 +97,23 @@ Simply download the [latest release from GitHub](https://github.com/kriomant/ch5
 ch57x-keyboard-tool [OPTIONS] <COMMAND>
 ```
 
+Commands and their descriptions:
+
 | Command                | Description                                               |
 | ---------------------- | --------------------------------------------------------- |
 | `show-keys`            | Display a list of all supported keys and modifiers        |
-| `validate`             | Validate key mappings config on stdin                     |
-| `upload`               | Upload key mappings from stdin to device                  |
+| `validate`             | Validate key mappings config from stdin                   |
+| `upload`               | Upload key mappings from stdin to the device              |
 | `led`                  | Select LED backlight mode                                 |
 | `help`, `-h`, `--help` | Print this message or the help of the given subcommand(s) |
 
-| Option                      | Description                | Notes            |
-| --------------------------- | -------------------------- | ---------------- |
-| `--vendor-id <VENDOR_ID>`   | Vendor ID of the keyboard  | Default: `4489`  |
-| `--product-id <PRODUCT_ID>` | Product ID of the keyboard | Default: `34960` |
-| `--address <ADDRESS>`       | Address of the keyboard    |                  |
+Options and their descriptions:
+
+| Option                      | Description                 | Notes            |
+| --------------------------- | --------------------------- | ---------------- |
+| `--vendor-id <VENDOR_ID>`   | Vendor ID of the keyboard   | Default: `4489`  |
+| `--product-id <PRODUCT_ID>` | Product ID of the keyboard  | Default: `34960` |
+| `--address <ADDRESS>`       | Address of the keyboard     |                  |
 
 ### Validate the config file
 
@@ -151,47 +155,47 @@ Get-Content your-config.yaml | ./ch57x-keyboard-tool validate
 
 ## Automation
 
-A common question/requests are about automation such as "How to run a script?", "emulate several keys", or "how to trigger an action with a key press?"
+A common question/request is about automation, such as "How to run a script?", "emulate several keys", or "how to trigger an action with a key press?"
 
-This tool does just one job: **writes your key bindings into a keyboard** and then exists.  
+This tool does just one job: **writes your key bindings into the keyboard** and then exits.  
 It does not listen for key presses.
-Automation based on key presses is not in the scope of this utility tool.
+Automation based on key presses is not within the scope of this utility tool.
 
-If you want any automation, use third-party automation tools like [BetterTouchTool](https://folivora.ai/) or 
+If you seek any automation, use third-party automation tools like [BetterTouchTool](https://folivora.ai/).
 
-1. Choose a chord you do not usually use (like `alt-ctrl-shift-1`)
-1. Assign the chord to a key
-2. Use a third-party automation tool to listen for this chord and have it perform the desired action
-3. Done! 🎉
+1. Choose a chord you do not usually use (like `alt-ctrl-shift-1`).
+2. Assign the chord to a key.
+3. Use a third-party automation tool to listen for this chord and have it perform the desired action.
+4. Done! 🎉
 
 ## Notes
 
 ### Number of layers
 
 All keyboards I have seen have three layers (three key configurations which may be switched).
-But, if your keyboard does not support layer switching, just keep a single layer in the configuration file.
+However, if your keyboard does not support layer switching, just keep a single layer in the configuration file.
 
 ### Custom keyboard layouts
 
 If you use a custom keyboard layout, like [Dvorak](https://en.wikipedia.org/wiki/Dvorak_keyboard_layout), you will need to write the keyboard key's [scancode](https://en.wikipedia.org/wiki/Scancode) in the configuration file (not the character that is produced).
 
-So use the QWERTY letter of the keyboard key you want to press.
+So, use the QWERTY letter of the keyboard key you want to press.
 
 ### 3x1 keys + 1 knob keyboard limitations
 
 This modification does support key modifiers (like `ctrl-`, `alt-`, and `cmd-`) for the first key in sequence only.
 
-So you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
+So, you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
 
 ### macOS vs Windows keyboard keys
 
-Friendly reminder that some keys have different names on macOS and Windows.  
+A friendly reminder that some keys have different names on macOS and Windows.  
 Make sure to use the correct key names in your configuration file.
 
 | Key Name          | macOS Key | Windows Key |
 | ----------------- | --------- | ----------- |
 | Command / Windows | `cmd`     | `win`       |
-| Option / Alt      | `cmd`     | `alt`       |
+| Option / Alt      | `opt`     | `alt`       |
 
 ## Diagnostics
 
@@ -225,7 +229,7 @@ Get-PnpDevice | Where-Object { $_.Class -eq 'USB' } | Format-Table Name, DeviceI
 
 ### Monitoring generated keyboard and mouse events
 
-The `keyboard` and `mouse` Python modules is the simplest and cross-platform way to monitor keyboard and mouse events.
+The simplest and cross-platform way to monitor keyboard and mouse events is using the `keyboard` and `mouse` Python modules.
 
 Monitoring keyboard:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 ![Last Commit Shields.io](https://img.shields.io/github/last-commit/kriomant/ch57x-keyboard-tool?style=for-the-badge) ![Release Workflow Badge](https://github.com/kriomant/ch57x-keyboard-tool/actions/workflows/release.yml/badge.svg)
 
+## Table of Contents <!-- omit in toc -->
+
+* [What is this?](#what-is-this)
+    * [Supported keyboards](#supported-keyboards)
+* [Installation](#installation)
+    * [Get prebuilt release](#get-prebuilt-release)
+    * [Build it yourself](#build-it-yourself)
+* [Usage](#usage)
+    * [Commands and options](#commands-and-options)
+    * [Validate the config file](#validate-the-config-file)
+    * [Upload the config to the keyboard](#upload-the-config-to-the-keyboard)
+    * [Change LED configuration](#change-led-configuration)
+    * [Windows / PowerShell](#windows--powershell)
+* [Automation](#automation)
+* [Notes](#notes)
+    * [Number of layers](#number-of-layers)
+    * [Custom keyboard layouts](#custom-keyboard-layouts)
+    * [3x1 keys + 1 knob keyboard limitations](#3x1-keys--1-knob-keyboard-limitations)
+    * [macOS vs Windows keyboard keys](#macos-vs-windows-keyboard-keys)
+* [Diagnostics](#diagnostics)
+    * [How to find and list connected USB devices](#how-to-find-and-list-connected-usb-devices)
+        * [macOS](#macos)
+        * [Linux](#linux)
+        * [Windows](#windows)
+    * [Monitoring generated keyboard and mouse events](#monitoring-generated-keyboard-and-mouse-events)
+* [Supported macro keyboards](#supported-macro-keyboards)
+    * [Photos of supported keyboards](#photos-of-supported-keyboards)
+
 ## What is this?
 
 This is a utility for programming small keyboards like this one:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is an utility for programming small keyboards like this one:
 
-![](doc/keyboard-12-2.png)
+![Picture of keyboard-12-2](doc/keyboard-12-2.png)
 
 Such keyboards are popular on AliExpress and seller usually sends software
 for programming, but it:
@@ -140,12 +140,13 @@ Monitoring keyboard:
 
 Monitoring mouse:
 
-    # Latest published 'mouse' module doesn't support MacOS, so use latest version from Git:
+    ## Latest published 'mouse' module doesn't support MacOS, so use latest version from Git:
     git clone https://github.com/boppreh/mouse
     cd mouse
     python3 -m mouse
 
-### Photos
+### Photos of Supported Keyboards
 
-![](doc/keyboard-6-1.png)
-![](doc/keyboard-3-1.jpg)
+| 3x2 with 1 knob                       | 3x1 with 1 knob                       | 3×3 with 2 knobs                        |
+| ------------------------------------- | ------------------------------------- | --------------------------------------- |
+| ![keyboard-6-1](doc/keyboard-6-1.png) | ![keyboard-3-1](doc/keyboard-3-1.jpg) | ![keyboard-12-2](doc/keyboard-12-2.png) |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# What is this?
+# ch57x-keyboard-tool Macro Keyboard Configuration Utility
+
+## What is this?
 
 This is an utility for programming small keyboards like this one:
 
@@ -6,10 +8,10 @@ This is an utility for programming small keyboards like this one:
 
 Such keyboards are popular on AliExpress and seller usually sends software
 for programming, but it:
- * requires Windows,
- * is very ugly and inconvenient,
- * can only program one key at a time
- * don't expose all keyboard features
+* requires Windows,
+* is very ugly and inconvenient,
+* can only program one key at a time
+* don't expose all keyboard features
 
 There are several modifications of such keyboards with different number of
 buttons and knobs ([see some photos](#photos)) and with/without Bluetooth.
@@ -18,10 +20,10 @@ Both wired and wireless keyboards are supported, however programming
 is possible though wire only in both cases!
 
 Utility was reported to work with:
- * 3×4 with 2 knobs (Bluetooth version)
- * 3×3 with 2 knobs
- * 3x2 with 1 knob
- * 3x1 with 1 knob (but [read about it's limitations](#3x1-keys--1-knob-keyboard-limitations))
+* 3×4 with 2 knobs (Bluetooth version)
+* 3×3 with 2 knobs
+* 3x2 with 1 knob
+* 3x1 with 1 knob (but [read about it's limitations](#3x1-keys--1-knob-keyboard-limitations))
 
 All these keyboards share same vendor/product IDs: 1189:8890 (hexadecimal).
 It is possible to override used vendor/product ID, but it is usually not needed.
@@ -31,18 +33,18 @@ I haven't seen such.
 **Ability to override vendor/product ID doesn't mean that you can use
 this software for programming arbitrary keyboards!**
 
-# How to get it?
+## How to get it?
 
-## Get prebuilt release
+### Get prebuilt release
 
 Download latest release from [GitHub releases](https://github.com/kriomant/ch57x-keyboard-tool/releases)
 
-## Build it yourself
+### Build it yourself
 
 Install *cargo* utility using [rustup](https://rustup.rs/), then execute
 `cargo install ch57x-keyboard-tool`.
 
-# How to use?
+## How to use?
 
 **Note**: on Windows you need to install [USBDK](https://github.com/daynix/UsbDk/releases) first.
 
@@ -67,13 +69,13 @@ You can also change LED configuration, if you keyboard supports it:
 
     ./ch57x-keyboard-tool led 1
 
-## Windows / PowerShell
+### Windows / PowerShell
 
 Use `Get-Content` for input redireciton:
 
     Get-Content your-config.yaml | ./ch57x-keyboard-tool validate
 
-## Automation
+### Automation
 
 The frequent question is "How to run script / emulate several keys / … on key press?"
 This tool does just one job — writes your key bindings into keyboard and then exists, it does not
@@ -84,16 +86,16 @@ or dozens of other.
 2. Use third-party tool to listen for this chord and perform action you want.
 3. Done!
 
-# Notes
+## Notes
 
-## Number of layers
+### Number of layers
 
 All keyboards I've seen have three layer (three keys configuration which
 may be switched). However I've been told there are keyboards without
 layer switch. If so, just keep single layer in configuration file and you
 are done.
 
-## Custom keyboard layouts
+### Custom keyboard layouts
 
 If you use custom keyboard layout, like Dvorak, note that what you
 write in configuration is in fact scan code of keyboard key and not
@@ -101,19 +103,19 @@ character that will be produced.
 
 So use QWERTY-letter of keyboard key you want to press.
 
-## 3x1 keys + 1 knob keyboard limitations
+### 3x1 keys + 1 knob keyboard limitations
 
 This modification does support key modifiers (like ctrl-, alt-) for the first key in sequence only.
 
 So you can use: `ctrl-alt-del,1,2`, but not `ctrl-alt-del,alt-1,2`.
 
-# Diagnostics
+## Diagnostics
 
 If you have any troubles using this software, please provide diagnostics.
 
-## Getting list of attached USB devices
+### Getting list of attached USB devices
 
-### MacOS
+#### MacOS
 
 
     ioreg -w0 -l -p IOUSB
@@ -122,12 +124,12 @@ or
 
     system_profiler SPUSBDataType
 
-### Linux
+#### Linux
 
 
     lsusb -v
 
-## Monitoring generated keyboard and mouse events
+### Monitoring generated keyboard and mouse events
 
 Most simple (and cross-platform) way I've found is using `keyboard` and `mouse` Python modules.
 
@@ -143,7 +145,7 @@ Monitoring mouse:
     cd mouse
     python3 -m mouse
 
-## Photos
+### Photos
 
 ![](doc/keyboard-6-1.png)
 ![](doc/keyboard-3-1.jpg)

--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ config has extensive documentation and examples inside.
 
 You can validate config:
 
-    ./ch57x-keyboard-tool validate < your-config.yaml
+```shell
+./ch57x-keyboard-tool validate < your-config.yaml
+```
 
 Use 'show-keys' command to list all supported modifier and key names.
 
 Finally, upload config to keyboard:
 
-    ./ch57x-keyboard-tool upload < your-config.yaml
+```shell
+./ch57x-keyboard-tool upload < your-config.yaml
+```
 
 Use 'sudo' if you get 'Access denied (insufficient permissions)':
 
@@ -67,7 +71,9 @@ Use 'sudo' if you get 'Access denied (insufficient permissions)':
 
 You can also change LED configuration, if you keyboard supports it:
 
-    ./ch57x-keyboard-tool led 1
+```shell
+./ch57x-keyboard-tool led 1
+```
 
 ### Windows / PowerShell
 
@@ -135,15 +141,19 @@ Most simple (and cross-platform) way I've found is using `keyboard` and `mouse` 
 
 Monitoring keyboard:
 
-    pip3 install keyboard
-    sudo python3 -m keyboard
+```shell
+pip3 install keyboard
+sudo python3 -m keyboard
+```
 
 Monitoring mouse:
+* The latest published 'mouse' module doesn't support macOS, so use the latest version from GitHub
 
-    ## Latest published 'mouse' module doesn't support MacOS, so use latest version from Git:
-    git clone https://github.com/boppreh/mouse
-    cd mouse
-    python3 -m mouse
+```shell
+git clone https://github.com/boppreh/mouse
+cd mouse
+python3 -m mouse
+```
 
 ### Photos of Supported Keyboards
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ This is a utility for programming small keyboards like this one:
 
 ![Picture of keyboard-12-2](doc/keyboard-12-2.png)
 
-Such macro keyboards are popular on AliExpress and sellers usually send software for programming, but it:
+Such macro keyboards are popular on AliExpress, and sellers often include software for programming, but:
 * requires Windows
 * is very ugly and inconvenient
 * can only program one key at a time
-* don't expose all keyboard features
+* do not expose all keyboard features
 
 There are several modifications of such keyboards with different numbers of buttons and knobs (See the [photos of supported keyboards](#photos-of-supported-keyboards)) and with/without Bluetooth.
 
 Both wired and wireless keyboards are supported.  
-⚠️ However, the keyboard must be connected to the computer with the USB cable when programming it.
+⚠️ However, the keyboard must be connected to the computer with the USB cable when programming.
 
 ### Supported keyboards
 
@@ -53,24 +53,24 @@ This utility was reported to work with:
 * 3×4 with 2 knobs (Bluetooth version)
 * 3×3 with 2 knobs
 * 3x2 with 1 knob
-* 3x1 with 1 knob (but [read about it's limitations](#3x1-keys--1-knob-keyboard-limitations))
+* 3x1 with 1 knob with [limitations](#3x1-keys--1-knob-keyboard-limitations))
 
 All these keyboards share the same vendor/product IDs: `1189:8890` (hexadecimal).
-It is possible to override used vendor/product ID, but it is usually not needed.
-Use it only if you find same-looking keyboard with other vendor/product ID,
+It is possible to override used vendor/product ID, but it is usually unnecessary.
+Use it only if you find the same-looking keyboard with other vendor/product ID,
 I haven't seen such.
 
-Refer to the [Supported Macro Keyboards](#supported-macro-keyboards) section for more details.
+For more details, refer to the [Supported Macro Keyboards](#supported-macro-keyboards) section.
 
 **⚠️ Ability to override vendor/product ID doesn't mean that you can use this software for programming arbitrary keyboards!**
 
 ## Installation
 
-There are two ways to get this software: prebuilt release or build it yourself.
+There are two ways to download the keyboard utility: prebuilt release or build it yourself.
 
-### Get prebuilt release
+### Get the prebuilt release
 
-Download the latest release from [GitHub releases](https://github.com/kriomant/ch57x-keyboard-tool/releases)
+Simply download the [latest release from GitHub](https://github.com/kriomant/ch57x-keyboard-tool/releases)
 
 ### Build it yourself
 
@@ -134,6 +134,10 @@ sudo ./ch57x-keyboard-tool upload < your-config.yaml
 If your keyboard supports it, you can change the LED configuration:
 
 ```shell
+# Turn off the LED
+./ch57x-keyboard-tool led 0
+
+# Set the LED to the first mode (likely "Steady on")
 ./ch57x-keyboard-tool led 1
 ```
 
@@ -153,23 +157,23 @@ This tool does just one job: **writes your key bindings into a keyboard** and th
 It does not listen for key presses.
 Automation based on key presses is not in the scope of this utility tool.
 
-If you want any automation, use third-party automation tools, like [BetterTouchTool](https://folivora.ai/).
+If you want any automation, use third-party automation tools like [BetterTouchTool](https://folivora.ai/) or 
 
-1. Choose some chord you do not usually use, like `alt-ctrl-shift-1` and assign it to a key
-2. Use a third-party tool to listen for this chord and perform the desired action
+1. Choose a chord you do not usually use (like `alt-ctrl-shift-1`)
+1. Assign the chord to a key
+2. Use a third-party automation tool to listen for this chord and have it perform the desired action
 3. Done! 🎉
 
 ## Notes
 
 ### Number of layers
 
-All keyboards I have seen have three layers (three key configurations which may be switched).  
-However, I have been told there are keyboards without layer switch.
-If so, just keep a single layer in the configuration file and you are done.
+All keyboards I have seen have three layers (three key configurations which may be switched).
+But, if your keyboard does not support layer switching, just keep a single layer in the configuration file.
 
 ### Custom keyboard layouts
 
-If you use a custom keyboard layout, like Dvorak, note that you will need to write the keyboard key's scan code in the configuration file (not the character that is produced).
+If you use a custom keyboard layout, like [Dvorak](https://en.wikipedia.org/wiki/Dvorak_keyboard_layout), you will need to write the keyboard key's [scancode](https://en.wikipedia.org/wiki/Scancode) in the configuration file (not the character that is produced).
 
 So use the QWERTY letter of the keyboard key you want to press.
 
@@ -221,7 +225,7 @@ Get-PnpDevice | Where-Object { $_.Class -eq 'USB' } | Format-Table Name, DeviceI
 
 ### Monitoring generated keyboard and mouse events
 
-The most simple (and cross-platform) way I have found is using `keyboard` and `mouse` Python modules.
+The `keyboard` and `mouse` Python modules is the simplest and cross-platform way to monitor keyboard and mouse events.
 
 Monitoring keyboard:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ch57x-keyboard-tool Macro Keyboard Configuration Utility
 
+![Last Commit Shields.io](https://img.shields.io/github/last-commit/kriomant/ch57x-keyboard-tool?style=for-the-badge) ![Release Workflow Badge](https://github.com/kriomant/ch57x-keyboard-tool/actions/workflows/release.yml/badge.svg)
+
 ## What is this?
 
 This is an utility for programming small keyboards like this one:

--- a/README.md
+++ b/README.md
@@ -105,16 +105,19 @@ Use `Get-Content` for input redirection:
 Get-Content your-config.yaml | ./ch57x-keyboard-tool validate
 ```
 
-### Automation
+## Automation
 
-The frequent question is "How to run script / emulate several keys / … on key press?"
-This tool does just one job — writes your key bindings into keyboard and then exists, it does not
-listen for pressed key. If you want any automation, use third-party automation tools, like BetterTouchTool
-or dozens of other.
+A common question/requests are about automation such as "How to run a script?", "emulate several keys", or "how to trigger an action with a key press?"
 
-1. Choose some chord you don't usually use, like 'alt-ctrl-shift-1' and assign to some key
-2. Use third-party tool to listen for this chord and perform action you want.
-3. Done!
+This tool does just one job: **writes your key bindings into a keyboard** and then exists.  
+It does not listen for key presses.
+Automation based on key presses is not in the scope of this utility tool.
+
+If you want any automation, use third-party automation tools, like [BetterTouchTool](https://folivora.ai/).
+
+1. Choose some chord you do not usually use, like `alt-ctrl-shift-1` and assign it to a key
+2. Use a third-party tool to listen for this chord and perform the desired action
+3. Done! 🎉
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,21 @@ Refer to the [Supported Macro Keyboards](#supported-macro-keyboards) section for
 
 **⚠️ Ability to override vendor/product ID doesn't mean that you can use this software for programming arbitrary keyboards!**
 
-## How to get it?
+## Installation
+
+There are two ways to get this software: prebuilt release or build it yourself.
 
 ### Get prebuilt release
 
-Download latest release from [GitHub releases](https://github.com/kriomant/ch57x-keyboard-tool/releases)
+Download the latest release from [GitHub releases](https://github.com/kriomant/ch57x-keyboard-tool/releases)
 
 ### Build it yourself
 
-Install *cargo* utility using [rustup](https://rustup.rs/), then execute
-`cargo install ch57x-keyboard-tool`.
+1. Install the *cargo* utility using [rustup](https://rustup.rs/)
+    * Brew: `brew install rustup-init && rustup-init`
+    * Linux: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+    * Windows: download and run [rustup-init.exe](https://win.rustup.rs/)
+1. Execute `cargo install ch57x-keyboard-tool`.
 
 ## How to use?
 

--- a/example-mapping.yaml
+++ b/example-mapping.yaml
@@ -41,12 +41,12 @@ layers:
       # Knobs are listed from top to bottom if vertical.
       # Knobs can be rotated counter-clockwise (ccw) or clockwise (cw)
       # and pressed down.
-      - ccw: 'wheelup'
-        press: 'click'
-        cw: 'wheeldown'
-      - ccw: 'shift-wheelup'
-        press: 'shift-click'
-        cw: 'shift-wheeldown'
+      - ccw: "wheelup"
+        press: "click"
+        cw: "wheeldown"
+      - ccw: "shift-wheelup"
+        press: "shift-click"
+        cw: "shift-wheeldown"
 
   - buttons:
       # Mouse events are clicks ('click/lclick', 'rclick', 'mclick') or
@@ -57,12 +57,12 @@ layers:
       - ["click+rclick", "wheeldown", "shift-wheelup", "ctrl-wheelup"]
       - ["alt-wheelup", "ctrl-click", "wheelup", "wheelup"]
     knobs:
-      - ccw: 'left'
-        press: 'enter'
-        cw: 'right'
-      - ccw: 'ctrl-left'
-        press: 'ctrl-enter'
-        cw: 'ctrl-right'
+      - ccw: "left"
+        press: "enter"
+        cw: "right"
+      - ccw: "ctrl-left"
+        press: "ctrl-enter"
+        cw: "ctrl-right"
 
   - buttons:
       # Multimedia commands are supported but
@@ -71,9 +71,9 @@ layers:
       - ["2", "3", "4", "5"]
       - ["6", "7", "8", "9"]
     knobs:
-      - ccw: 'volumedown'
-        press: 'mute'
-        cw: 'volumeup'
-      - ccw: 'd'
-        press: 'e'
-        cw: 'f'
+      - ccw: "volumedown"
+        press: "mute"
+        cw: "volumeup"
+      - ccw: "d"
+        press: "e"
+        cw: "f"

--- a/example-mapping.yaml
+++ b/example-mapping.yaml
@@ -1,7 +1,7 @@
-# Normal keyboard orienation is when buttons are on the left
-# side and knobs are on the right. However, you may want to use
-# the keyboard in another orienation. To avoid remapping button
-# positions in your head, just set it here.
+# Normal keyboard orientation is when
+# buttons are on the left side and knobs are on the right.
+# However, you may want to use the keyboard in another orientation.
+# To avoid remapping button positions in your head, just set it here.
 # Possible values are:
 #   (horizontal)
 #   - 'normal': buttons on the left, knobs on the right
@@ -11,10 +11,9 @@
 #   - 'counterclockwise': buttons on the bottom, knobs on the top
 orientation: normal
 
-# There are different models of keyboard with different numbers
-# of buttons and knobs. Set it here for proper handling.
-# Count rows and columns with the keyboard in normal orienation,
-# with knobs on the right side.
+# Different keyboard models have different numbers of buttons and knobs.
+# Set it here for proper handling.
+# Count rows and columns with the keyboard in normal orientation (knobs on the right)
 rows: 3
 columns: 4
 knobs: 2
@@ -22,25 +21,24 @@ knobs: 2
 # Layers are sets of alternative key mappings.
 # The current layer is changed using a button on the side of the keyboard
 # and displayed with LEDs on top (only for the moment of changing).
-# All keyboards I saw had three layers, but I suppose other variants
-# exist.
+# All keyboards I saw had three layers, but I suppose other variants exist.
 layers:
   - buttons:
-      # Array of buttons. In horizontal orienations it's `rows` rows
-      # `columns` buttons each. In vertical: `columns` rows
-      # `rows` buttons each.
+      # Array of buttons.
+      # In horizontal orientations it's `rows` rows `columns` buttons each.
+      # In vertical: `columns` rows `rows` buttons each.
       # Each entry is either a sequence of 'chords' or a mouse event.
-      # A chord is a combination of one key with optional modifiers,
-      # like 'b', 'ctrl-alt-a' or 'win-rctrl-backspace'. It can also
-      # be just modifiers without a key: 'ctrl-alt'.
+      # A chord is a combination of one key with optional modifiers,
+      # like 'b', 'ctrl-alt-a' or 'win-rctrl-backspace'.
+      # It can also be just modifiers without a key: 'ctrl-alt'.
       # You may combine up to 5 chords into a sequence using commas: 'ctrl-v,ctrl-c'.
       # Arbitrary scan codes (decimal) may be given like this: '<101>'.
       - ["a", "ctrl-a", "alt-shift", "alt-ctrl,ctrl-b"]
       - ["e", "f", "g", "h"]
       - ["<100>", "j", "k", "l"]
     knobs:
-      # Knobs are listed from left to right if horizontal
-      # and from top to bottom if vertical.
+      # Knobs are listed from left to right if horizontal.
+      # Knobs are listed from top to bottom if vertical.
       # Knobs can be rotated counter-clockwise (ccw) or clockwise (cw)
       # and pressed down.
       - ccw: 'wheelup'
@@ -67,8 +65,8 @@ layers:
         cw: 'ctrl-right'
 
   - buttons:
-      # Multimedia commands are also supported. They cannot be mixed with
-      # normal keys and modifiers.
+      # Multimedia commands are supported but
+      # cannot be mixed with normal keys and modifiers.
       - ["play", "prev", "next", "mute"]
       - ["2", "3", "4", "5"]
       - ["6", "7", "8", "9"]


### PR DESCRIPTION
## Changes to README.md
- Add Commands and options table to the Usage section
- Add Last Commit and Release Workflow badges
- Added macOS vs Windows Keyboard key sections
- Added Supported Macro Keyboards section
- Added Table of Contents
- Clarify the Supported keyboards section
- Polished overall writing
- Fix up Photos
- Mentioned about turning off the LED
- Improved USB device listing section
- Markdown Fix - Header & bullet points
- Markdown format code blocks
- Polish Diagnostics section
- Polished Automation section
- Polished Installation section
- Polished the "What is this?" section
- Polished Usage section

## Added MIT License
- In response to the issue #45
- Referenced Cargo.toml

## Changes to example-mapping.yaml
- Consistent formatting
- Improved readability of documentation

---

Thank you for building this tool! It was exactly what I needed and hope I can help your project in a small way.