### PR TITLE
Prevent interface parameter check from exiting interface loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,20 +145,20 @@ fn find_interface_and_endpoint(
                 intf.descriptors().format("\n")
             )
         })?;
-        ensure!(
-            intf_desc.class_code() == 0x03
-                && intf_desc.sub_class_code() == 0x00
-                && intf_desc.protocol_code() == 0x00,
-            "unexpected interface parameters: {:#?}",
-            intf_desc
-        );
 
         // Look for suitable endpoints
         if let Some(endpt_desc) = intf_desc.endpoint_descriptors().find(|ep| {
             ep.transfer_type() == TransferType::Interrupt && ep.address() == endpoint_addr
         }) {
             debug!("Found endpoint {endpt_desc:?}");
-            return Ok((iface_num, endpt_desc.address()));
+            if intf_desc.class_code() == 0x03
+                && intf_desc.sub_class_code() == 0x00
+                && intf_desc.protocol_code() == 0x00
+            {
+                return Ok((iface_num, endpt_desc.address()));
+            } else {
+                debug!("unexpected interface parameters: {:#?}", intf_desc);
+            }
         }
     }
 


### PR DESCRIPTION
This partially addresses #50 

The regression in was introduced in e360b93. In that commit the code was changed from using a fixed interface number of 1:

```rust
let intf = conf_desc
    .interfaces()
    .find(|intf| intf.number() == 1)
    .ok_or_else(|| {
        anyhow!("interface #1 not found, interface numbers:\n{:#?}",
            conf_desc.interfaces().map(|i| i.number()).format(", "))
    })?;
```

to looping over all the interfaces.

Part of the issue is that the interface parameter check is now run against each candidate interface and if it doesn't match, the loop is exited. This PR changes this so that the loop continues if the parameters do not match expectations so that it's possible for a subsequent interface to be found.

With this change in place my board (1 row, 3 button, 1 knob) still fails to upload with this error:

> No valid interface/endpoint combination found!

This caused by another change of logic in e360b93. Previously the endpoint descriptor was found using the value passed by the developer options or the first one was used if that was not supplied:

```rust
let endpt_desc = if let Some(endpoint_address) = options.devel_options.endpoint_address {
    endpt_descs
        .find(|d| d.address() == endpoint_address)
        .ok_or_else(|| anyhow!("endpoint with address {} not found", endpoint_address))?
} else {
    endpt_descs
        .exactly_one()
        .map_err(|_| {
            anyhow!(indoc!(
                "single interrupt endpoint is expected, got:
                {:#?}

                You may try to choose one using --endpoint-address"
            ), intf_desc.endpoint_descriptors().format("\n"))
        })?
};
```

Now the endpoint address defaults to 4 if not supplied, which does not match my board which uses this decriptor (address 2):

```rust
EndpointDescriptor {
    bLength: 7,
    bDescriptorType: 5,
    bEndpointAddress: 2,
    bmAttributes: 3,
    wMaxPacketSize: 64,
    bInterval: 10,
}
```

I can successfully program my board if I the changes in this PR are applied and I pass `--endpoint-address 2`.