### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ You may also get list of supported key names using:
 ### Validate the config file
 
 ```shell
-./ch57x-keyboard-tool validate your-config.yaml
+./ch57x-keyboard-tool validate < your-config.yaml
 ```
 
 ### Upload the config to the keyboard
 
 ```shell
-./ch57x-keyboard-tool upload your-config.yaml
+./ch57x-keyboard-tool upload < your-config.yaml
 ```
 
 Use 'sudo' if you get 'Access denied (insufficient permissions)':
 
 ```shell
-sudo ./ch57x-keyboard-tool upload your-config.yaml
+sudo ./ch57x-keyboard-tool upload < your-config.yaml
 ```
 
 ### Change LED configuration


### PR DESCRIPTION
Reflecting the changed way to use upload and validate

`./ch57x-keyboard-tool upload 4knob-mapping.yaml` gives an error:
> error: Found argument '4knob-mapping.yaml' which wasn't expected, or isn't valid in this context

`./ch57x-keyboard-tool upload < 4knob-mapping.yaml` works.