### PR TITLE
Add 0x8850 to supported product IDs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ fn open_keyboard(devel_options: &DevelOptions) -> Result<Box<dyn Keyboard>> {
     );
 
     let preferred_endpint = match id_product {
-        0x8840 | 0x8842 => k884x::Keyboard884x::preferred_endpoint(),
+        0x8840 | 0x8842 | 0x8850 => k884x::Keyboard884x::preferred_endpoint(),
         0x8890 => k8890::Keyboard8890::preferred_endpoint(),
         _ => unreachable!("unsupported device"),
     };
@@ -196,7 +196,7 @@ fn open_keyboard(devel_options: &DevelOptions) -> Result<Box<dyn Keyboard>> {
         .context("claim interface")?;
 
     match id_product {
-        0x8840 | 0x8842 => {
+        0x8840 | 0x8842 | 0x8850 => {
             k884x::Keyboard884x::new(handle, endpt_addr).map(|v| Box::new(v) as Box<dyn Keyboard>)
         }
         0x8890 => {


### PR DESCRIPTION
Was able to program my keyboard with 0x8850 by just whitelisting it.
Does only work with up to 3 knobs though!
Fixes #89

~~Was not able to test backlight mode, as mine does not have them.~~ (Nevermind, it should have backlight, but it's not working with this simple fix it seems)

