### PR TITLE
add aarch64 build target for devices like Raspberry Pi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
   push:
     tags:
       - "v[0-9]+.*"
-  release:
-    types: [created]
 
 jobs:
   create-release:


### PR DESCRIPTION
Add an aarch64 build target in release workflow so that Raspberry Pi devices have easy to download built assets.

Also remove the ad-hoc build type because the action would not work, unless used in a tag, which seem odd.

Also bump actions/checkout to the lastest release.

Also locked the release build, so that cargo drift would get picked up sooner.

Also updated the ```.gitignore``` file to ignore some more files on macOS.

This PR should resolve #150 
