### PR TITLE
Clean up README formatting for `### Windows / Powershell` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,11 @@ Backlight additionally supports *white*.
 
 # Set the LED to the first mode (likely "Steady on")
 ./ch57x-keyboard-tool led 1
-```
 
 ### Windows / PowerShell
 
 Use `Get-Content` for input redirection:
-
-```shell
+```Powershell
 Get-Content your-config.yaml | ./ch57x-keyboard-tool validate
 ```
 


### PR DESCRIPTION
`### Windows Powershell` was mistakenly included in the codeblock.

1. Moved header out of codeblock.
2. Changed codeblock formatting specifier to `Powershell`

<img width="848" height="338" alt="Clipboard_11-09-2025_01" src="https://github.com/user-attachments/assets/028b42bc-51da-4919-a366-68efab41c58e" />
