### PR TITLE
Add support for 514c:8851 keyboard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,7 @@ fn open_device(devel_options: &DevelOptions) -> Result<(DeviceHandle<Context>, u
     );
 
     let preferred_endpoint = match id_product {
-        0x8840 | 0x8842 | 0x8850 => k884x::Keyboard884x::preferred_endpoint(),
+        0x8840 | 0x8842 | 0x8850 | 0x8851 => k884x::Keyboard884x::preferred_endpoint(),
         0x8890 => k8890::Keyboard8890::preferred_endpoint(),
         _ => unreachable!("unsupported device"),
     };
@@ -245,7 +245,7 @@ fn open_device(devel_options: &DevelOptions) -> Result<(DeviceHandle<Context>, u
 
 fn create_driver(id_product: u16, buttons: u8, knobs: u8) -> Result<Box<dyn Keyboard>> {
     let keyboard: Box<dyn Keyboard> = match id_product {
-        0x8840 | 0x8842 | 0x8850 => {
+        0x8840 | 0x8842 | 0x8850 | 0x8851 => {
             Box::new(k884x::Keyboard884x::new(buttons, knobs)?)
         }
         0x8890 => {


### PR DESCRIPTION
## Summary

- Adds product ID `0x8851` to the `k884x` driver match arms in `open_device` and `create_driver`
- Enables support for the `514c:8851` 2-key macro keyboard variant
- Tested and confirmed working with `--vendor-id 20812 --product-id 34897 --endpoint-address 2`

Closes #162

## Notes

- Follows the same pattern as the existing `0x8850` support (in match arms, not in `PRODUCT_IDS`, since the vendor ID `0x514c` differs from the default `0x1189`)
- The device's programming interface is on endpoint `0x02` (not `0x04`), so users need `--endpoint-address 2`
- Issue #162 also mentions a 3-button (no knob) variant with the same PID — that should work too since the layout is defined in the YAML config

## Test plan

- [x] Validated config with `validate` command
- [x] Uploaded key bindings to a physical `514c:8851` device (2 keys, no knobs)
- [x] Confirmed keys send expected keycodes after upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)