### PR TITLE
Add K8850 LED support with per-key RGB protocol

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,2 +1,4 @@
 pub const VENDOR_ID: u16 = 0x1189;
-pub const PRODUCT_IDS: [u16; 3] = [0x8840, 0x8842, 0x8890];
+/// Some 8850 keyboards use a different vendor ID (0x514C).
+pub const VENDOR_ID_ALT: u16 = 0x514C;
+pub const PRODUCT_IDS: [u16; 4] = [0x8840, 0x8842, 0x8850, 0x8890];

--- a/src/keyboard/k884x.rs
+++ b/src/keyboard/k884x.rs
@@ -213,7 +213,7 @@ impl Keyboard for Keyboard884x {
 impl Keyboard884x {
     pub fn new(buttons: u8, knobs: u8) -> Result<Self> {
         ensure!(
-            (buttons <= 15 && knobs <= 3) ||
+            (buttons <= 16 && knobs <= 3) ||
             (buttons <= 12 && knobs <= 4),
             "unsupported combination of buttons and knobs count"
         );
@@ -221,20 +221,18 @@ impl Keyboard884x {
     }
 
     fn to_key_id(&self, key: Key) -> Result<u8> {
-        const MAX_NUMBER_OF_BUTTONS: u8 = 15;
+        // Key IDs are 1-based: buttons use IDs 1..=buttons, knobs follow after.
+        // Exception: keyboards with 12 buttons and 4 knobs map the fourth knob
+        // to IDs 13-15 (reusing button slots) instead of the expected 25-27.
+        const BASE_BUTTONS: u8 = 15;
         match key {
-            Key::Button(n) if n >= MAX_NUMBER_OF_BUTTONS => Err(anyhow::anyhow!("invalid key index")),
-
-            // There are keyboards with 15 buttons and 3 knobs, so NUMBER_OF_BUTTONS is correct
-            // overall. However, there are keyboards with 12 buttons and 4 knobs, and fourth knob
-            // doesn't use 25-27 codes as it should, but use 13-15, which are allocated for buttons.
-            // So, it seems, they exchange one row of buttons to extra knob.
+            Key::Button(n) if n >= self.buttons => Err(anyhow::anyhow!("invalid key index")),
             Key::Button(n) if n >= 12 && self.knobs == 4 => Err(anyhow::anyhow!("invalid key index")),
             Key::Knob(3, action) if self.buttons <= 12 => Ok(13 + (action as u8)),
 
             Key::Button(n) => Ok(n + 1),
             Key::Knob(n, _) if n >= 3 => Err(anyhow::anyhow!("invalid knob index")),
-            Key::Knob(n, action) => Ok(MAX_NUMBER_OF_BUTTONS + 1 + 3 * n + (action as u8)),
+            Key::Knob(n, action) => Ok(BASE_BUTTONS + 1 + 3 * n + (action as u8)),
         }
     }
 }

--- a/src/keyboard/k8850.rs
+++ b/src/keyboard/k8850.rs
@@ -1,0 +1,261 @@
+use std::str::FromStr;
+
+use anyhow::{ensure, Result};
+use clap::Parser;
+use nom::{IResult, branch::alt, bytes::complete::tag, character::complete::alpha1, combinator::{map, map_res, value}, sequence::preceded};
+
+use super::{Key, Keyboard, Macro, send_message};
+use super::k884x::Keyboard884x;
+
+/// LED modes for the K8850 firmware (confirmed via hardware testing).
+///
+/// The K8850 uses per-key RGB with an explicit mode byte, unlike the K884x
+/// which encodes mode and color into a single byte.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LedMode {
+    /// LEDs off (mode 0)
+    Off,
+    /// Static color - all keys show the specified color (mode 1)
+    Static(Color),
+    /// Reactive - keys light up on press (mode 2)
+    Reactive(Color),
+    /// Ripple - ripple effect from pressed key (mode 3)
+    Ripple(Color),
+    /// Rainbow chase across keys (mode 4, color ignored)
+    Rainbow,
+}
+
+impl LedMode {
+    fn mode_byte(&self) -> u8 {
+        match self {
+            LedMode::Off => 0,
+            LedMode::Static(_) => 1,
+            LedMode::Reactive(_) => 2,
+            LedMode::Ripple(_) => 3,
+            LedMode::Rainbow => 4,
+        }
+    }
+
+    fn color(&self) -> Color {
+        match self {
+            LedMode::Off => Color { r: 0, g: 0, b: 0 },
+            LedMode::Static(c) | LedMode::Reactive(c) | LedMode::Ripple(c) => *c,
+            LedMode::Rainbow => Color { r: 0, g: 0, b: 0 },
+        }
+    }
+}
+
+impl FromStr for LedMode {
+    type Err = nom::error::Error<String>;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        crate::parse::from_str(led_mode, s)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl FromStr for Color {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        // Try named colors first
+        match s.to_lowercase().as_str() {
+            "red" => return Ok(Color { r: 255, g: 0, b: 0 }),
+            "green" => return Ok(Color { r: 0, g: 255, b: 0 }),
+            "blue" => return Ok(Color { r: 0, g: 0, b: 255 }),
+            "white" => return Ok(Color { r: 255, g: 255, b: 255 }),
+            "yellow" => return Ok(Color { r: 255, g: 255, b: 0 }),
+            "cyan" => return Ok(Color { r: 0, g: 255, b: 255 }),
+            "magenta" => return Ok(Color { r: 255, g: 0, b: 255 }),
+            "orange" => return Ok(Color { r: 255, g: 128, b: 0 }),
+            "purple" => return Ok(Color { r: 128, g: 0, b: 255 }),
+            _ => {}
+        }
+        // Try hex: #RRGGBB
+        if let Some(hex) = s.strip_prefix('#') {
+            if hex.len() == 6 {
+                let r = u8::from_str_radix(&hex[0..2], 16).map_err(|e| e.to_string())?;
+                let g = u8::from_str_radix(&hex[2..4], 16).map_err(|e| e.to_string())?;
+                let b = u8::from_str_radix(&hex[4..6], 16).map_err(|e| e.to_string())?;
+                return Ok(Color { r, g, b });
+            }
+        }
+        Err(format!("unknown color '{}'. Use: red, green, blue, white, yellow, cyan, magenta, orange, purple, or #RRGGBB", s))
+    }
+}
+
+fn named_color(s: &str) -> IResult<&str, Color> {
+    map_res(alpha1, Color::from_str)(s)
+}
+
+fn led_mode(s: &str) -> IResult<&str, LedMode> {
+    alt((
+        value(LedMode::Off, tag("off")),
+        map(preceded(tag("static "), named_color), LedMode::Static),
+        map(preceded(tag("reactive "), named_color), LedMode::Reactive),
+        map(preceded(tag("ripple "), named_color), LedMode::Ripple),
+        value(LedMode::Rainbow, tag("rainbow")),
+    ))(s)
+}
+
+fn parse_led_mode(s: &str) -> Result<LedMode, String> {
+    crate::parse::from_str(led_mode, s).map_err(|e| format!("Invalid LED mode: {:?}", e))
+}
+
+#[derive(Parser, Debug)]
+struct LedArgs {
+    /// Layer to set the LED (0-2)
+    layer: u8,
+
+    /// LED mode and color (e.g. "static red", "reactive #FF0000", "rainbow", "off")
+    #[arg(value_parser=parse_led_mode)]
+    mode: LedMode,
+}
+
+/// Number of addressable key slots in the LED packet.
+const NUM_KEY_SLOTS: usize = 16;
+
+/// Driver for keyboards with product ID 0x8850 (e.g. XZKJ-16key_3knob).
+///
+/// Key bindings use the same protocol as the K884x family, but the LED
+/// protocol is completely different:
+///
+/// 1. An INIT packet `[0x03, 0xFB, 0xFB, 0xFB, ...]` must be sent first
+///    to put the device into configuration mode.
+///
+/// 2. LED data uses per-key RGB with an explicit mode byte:
+///    `[0x03, 0xFE, 0xB0, layer, mode, R, G, B, <16 × RGB per key>]`
+///
+///    - layer: 0-indexed (0, 1, 2)
+///    - mode: 0=off, 1=static, 2=reactive, 3=ripple, 4=rainbow
+///    - R,G,B: base color (used as the "selected" color)
+///    - per-key RGB: 16 keys × 3 bytes = 48 bytes of individual key colors
+///
+/// The K884x LED protocol (single encoded mode+color byte) is silently
+/// ignored by 8850 firmware.
+pub struct Keyboard8850 {
+    inner: Keyboard884x,
+}
+
+impl Keyboard for Keyboard8850 {
+    fn bind_key(&self, layer: u8, key: Key, expansion: &Macro, output: &mut Vec<u8>) -> Result<()> {
+        self.inner.bind_key(layer, key, expansion, output)
+    }
+
+    fn set_led(&mut self, args: &[String], output: &mut Vec<u8>) -> Result<()> {
+        let led_args = LedArgs::try_parse_from(args)?;
+
+        let layer = led_args.layer;
+        ensure!(layer < 3, "Layer must be 0-2");
+
+        let mode = led_args.mode.mode_byte();
+        let color = led_args.mode.color();
+
+        // Send INIT packet - required for the 8850 to accept LED configuration.
+        // The firmware enters a configuration mode upon receiving this.
+        send_message(output, &[0x03, 0xFB, 0xFB, 0xFB]);
+
+        // Build LED packet with per-key RGB data.
+        // Format: [0x03, 0xFE, 0xB0, layer, mode, R, G, B, key0_R, key0_G, key0_B, ...]
+        let mut msg = vec![0x03, 0xFE, 0xB0, layer, mode, color.r, color.g, color.b];
+        for _ in 0..NUM_KEY_SLOTS {
+            msg.extend_from_slice(&[color.r, color.g, color.b]);
+        }
+        // Truncate to 64 bytes (send_message pads to 64)
+        msg.truncate(64);
+        send_message(output, &msg);
+
+        Ok(())
+    }
+
+    fn preferred_endpoint() -> u8 where Self: Sized {
+        0x04
+    }
+}
+
+impl Keyboard8850 {
+    pub fn new(buttons: u8, knobs: u8) -> Result<Self> {
+        Ok(Self {
+            inner: Keyboard884x::new(buttons, knobs)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keyboard::assert_messages;
+
+    #[test]
+    fn test_led_static_red() {
+        let mut kb = Keyboard8850::new(16, 3).unwrap();
+        let mut output = Vec::new();
+        kb.set_led(&["led".to_string(), "0".to_string(), "static red".to_string()], &mut output).unwrap();
+
+        assert_eq!(output.len(), 2 * 64); // INIT + LED packet
+
+        // Check INIT packet
+        assert_eq!(output[0], 0x03);
+        assert_eq!(output[1], 0xFB);
+        assert_eq!(output[2], 0xFB);
+        assert_eq!(output[3], 0xFB);
+
+        // Check LED packet
+        let led = &output[64..128];
+        assert_eq!(led[0], 0x03);
+        assert_eq!(led[1], 0xFE);
+        assert_eq!(led[2], 0xB0);
+        assert_eq!(led[3], 0x00); // layer 0
+        assert_eq!(led[4], 0x01); // mode 1 (static)
+        assert_eq!(led[5], 0xFF); // R
+        assert_eq!(led[6], 0x00); // G
+        assert_eq!(led[7], 0x00); // B
+        // First per-key color
+        assert_eq!(led[8], 0xFF);  // key0 R
+        assert_eq!(led[9], 0x00);  // key0 G
+        assert_eq!(led[10], 0x00); // key0 B
+    }
+
+    #[test]
+    fn test_led_off() {
+        let mut kb = Keyboard8850::new(16, 3).unwrap();
+        let mut output = Vec::new();
+        kb.set_led(&["led".to_string(), "0".to_string(), "off".to_string()], &mut output).unwrap();
+
+        let led = &output[64..128];
+        assert_eq!(led[3], 0x00); // layer 0
+        assert_eq!(led[4], 0x00); // mode 0 (off)
+    }
+
+    #[test]
+    fn test_led_rainbow() {
+        let mut kb = Keyboard8850::new(16, 3).unwrap();
+        let mut output = Vec::new();
+        kb.set_led(&["led".to_string(), "1".to_string(), "rainbow".to_string()], &mut output).unwrap();
+
+        let led = &output[64..128];
+        assert_eq!(led[3], 0x01); // layer 1
+        assert_eq!(led[4], 0x04); // mode 4 (rainbow)
+    }
+
+    #[test]
+    fn parse_led_modes() {
+        assert_eq!("off".parse(), Ok(LedMode::Off));
+        assert_eq!("static red".parse(), Ok(LedMode::Static(Color { r: 255, g: 0, b: 0 })));
+        assert_eq!("reactive blue".parse(), Ok(LedMode::Reactive(Color { r: 0, g: 0, b: 255 })));
+        assert_eq!("ripple green".parse(), Ok(LedMode::Ripple(Color { r: 0, g: 255, b: 0 })));
+        assert_eq!("rainbow".parse(), Ok(LedMode::Rainbow));
+    }
+
+    #[test]
+    fn parse_hex_color() {
+        assert_eq!(Color::from_str("#FF8000"), Ok(Color { r: 255, g: 128, b: 0 }));
+        assert_eq!(Color::from_str("#000000"), Ok(Color { r: 0, g: 0, b: 0 }));
+    }
+}

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod k884x;
+pub(crate) mod k8850;
 pub(crate) mod k8890;
 
 use crate::parse;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::io::{BufReader, Read, StdinLock};
 use crate::config::Config;
 use crate::consts::PRODUCT_IDS;
 use crate::keyboard::{
-    k884x, k8890, Keyboard, KnobAction, MediaCode, Modifier,
+    k884x, k8850, k8890, Keyboard, KnobAction, MediaCode, Modifier,
     WellKnownCode,
 };
 use crate::options::{Command, LedCommand, TestLedCommand};
@@ -218,7 +218,8 @@ fn open_device(devel_options: &DevelOptions) -> Result<(DeviceHandle<Context>, u
     );
 
     let preferred_endpoint = match id_product {
-        0x8840 | 0x8842 | 0x8850 => k884x::Keyboard884x::preferred_endpoint(),
+        0x8840 | 0x8842 => k884x::Keyboard884x::preferred_endpoint(),
+        0x8850 => k8850::Keyboard8850::preferred_endpoint(),
         0x8890 => k8890::Keyboard8890::preferred_endpoint(),
         _ => unreachable!("unsupported device"),
     };
@@ -245,8 +246,11 @@ fn open_device(devel_options: &DevelOptions) -> Result<(DeviceHandle<Context>, u
 
 fn create_driver(id_product: u16, buttons: u8, knobs: u8) -> Result<Box<dyn Keyboard>> {
     let keyboard: Box<dyn Keyboard> = match id_product {
-        0x8840 | 0x8842 | 0x8850 => {
+        0x8840 | 0x8842 => {
             Box::new(k884x::Keyboard884x::new(buttons, knobs)?)
+        }
+        0x8850 => {
+            Box::new(k8850::Keyboard8850::new(buttons, knobs)?)
         }
         0x8890 => {
             Box::new(k8890::Keyboard8890::new())
@@ -257,6 +261,8 @@ fn create_driver(id_product: u16, buttons: u8, knobs: u8) -> Result<Box<dyn Keyb
 }
 
 fn find_device(devel_options: &DevelOptions) -> Result<(Device<Context>, DeviceDescriptor, u16)> {
+    use crate::consts::VENDOR_ID_ALT;
+
     let options = vec![
         #[cfg(windows)] rusb::UsbOption::use_usbdk(),
     ];
@@ -273,7 +279,11 @@ fn find_device(devel_options: &DevelOptions) -> Result<(Device<Context>, DeviceD
             desc.product_id()
         );
         let product_id = desc.product_id();
-        if desc.vendor_id() == devel_options.vendor_id
+        // Match the user-specified VID, or also try the alternate VID (0x514C)
+        // used by some 8850 keyboards.
+        let vid_match = desc.vendor_id() == devel_options.vendor_id
+            || desc.vendor_id() == VENDOR_ID_ALT;
+        if vid_match
             && match devel_options.product_id {
                 Some(prod_id) => prod_id == product_id,
                 None => PRODUCT_IDS.contains(&product_id),


### PR DESCRIPTION
## Summary

The K8850 (VID `0x514C`, PID `0x8850`) uses a different LED protocol than the K884x family. The existing K884x LED command is **silently ignored** by 8850 firmware. This PR adds a dedicated K8850 driver with the correct LED protocol, confirmed through hardware testing on a XZKJ-16key_3knob (4x4 keys + 3 rotary encoders).

### Key findings from hardware testing:

- The 8850 requires an **INIT packet** `[0x03, 0xFB, 0xFB, 0xFB]` before LED writes
- LED data uses **per-key RGB**: `[0x03, 0xFE, 0xB0, layer, mode, R, G, B, <16 × RGB>]`
- Layers are **0-indexed** (not 1-indexed like K884x)
- LED modes: `0`=off, `1`=static, `2`=reactive, `3`=ripple, `4`=rainbow
- **Mode 1 (static) must be explicitly set** for any color to display
- Supports **full RGB colors** (not limited to 7 preset colors)

### Changes:

- **New `k8850.rs` driver** — dedicated LED handling, delegates key binding to K884x
- **VID `0x514C` added** to device discovery (used by some 8850 keyboards)
- **`0x8850` added to `PRODUCT_IDS`** for auto-detection
- **16-button support** in K884x button validation (was capped at 15)

### LED usage for 8850:

```
ch57x-keyboard-tool led 0 "static red"
ch57x-keyboard-tool led 0 "reactive blue"
ch57x-keyboard-tool led 1 "ripple green"
ch57x-keyboard-tool led 0 rainbow
ch57x-keyboard-tool led 0 off
```

### Additional notes:

- The 8850 firmware has a ~60 second timeout after which live LED updates stop working (device must be power-cycled via BT/wired switch). This is a firmware-level limitation, not something the tool can work around.
- Mode 5 ("rainbow rows") crashes the firmware and should be avoided.
- The protocol was reverse-engineered from MINI_KEYBOARD.exe (SIKAI/Energy Fort configuration tool from szxiaozi.com) using Frida HID hooks.

Relates to #89, #153

## Test plan

- [x] Tested LED static mode with red, green, blue, white on hardware
- [x] Tested LED off mode
- [x] Tested reactive and ripple modes
- [x] Confirmed K884x LED protocol is silently ignored by 8850
- [x] Confirmed INIT packet is required for LED writes
- [x] Key binding protocol verified (same as K884x)
- [ ] Unit tests included for packet format validation