### PR TITLE
Add support for 514c:8851 macropad

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,7 @@ const SUPPORTED_DEVICES: &[(KeyboardModel, u16, u16)] = &[
     (KeyboardModel::Ch57x_1, 0x1189, 0x8850),
     (KeyboardModel::Ch57x_2, 0x1189, 0x8890),
     (KeyboardModel::Ch57x_3, 0x514c, 0x8850),
+    (KeyboardModel::Ch57x_1, 0x514c, 0x8851),
 ];
 
 impl KeyboardModel {


### PR DESCRIPTION
This adds support for macropads with vendor ID 0x514c and product ID 0x8851. Tested working with model ch57x-1 driver.

Note: requires `--endpoint-address 2` flag as the device uses endpoint 0x02 for OUT transfers (preferred endpoint defaults to 0x04).