### PR TITLE
Auto-detect endpoint address: fallback to any OUT endpoint if preferred not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,19 +175,30 @@ fn find_interface_and_endpoint(
             )
         })?;
 
-        // Look for suitable endpoints
+        // Check that this is a generic HID interface
+        let is_hid = intf_desc.class_code() == 0x03
+            && intf_desc.sub_class_code() == 0x00
+            && intf_desc.protocol_code() == 0x00;
+
+        if !is_hid {
+            debug!("skipping non-HID interface: {:#?}", intf_desc);
+            continue;
+        }
+
+        // First try to find exact endpoint match
         if let Some(endpt_desc) = intf_desc.endpoint_descriptors().find(|ep| {
             ep.transfer_type() == TransferType::Interrupt && ep.address() == endpoint_addr
         }) {
-            debug!("Found endpoint {endpt_desc:?}");
-            if intf_desc.class_code() == 0x03
-                && intf_desc.sub_class_code() == 0x00
-                && intf_desc.protocol_code() == 0x00
-            {
-                return Ok((iface_num, endpt_desc.address()));
-            } else {
-                debug!("unexpected interface parameters: {:#?}", intf_desc);
-            }
+            debug!("Found preferred endpoint {endpt_desc:?}");
+            return Ok((iface_num, endpt_desc.address()));
+        }
+
+        // Fallback: find any interrupt OUT endpoint
+        if let Some(endpt_desc) = intf_desc.endpoint_descriptors().find(|ep| {
+            ep.transfer_type() == TransferType::Interrupt && (ep.address() & 0x80) == 0
+        }) {
+            debug!("Preferred endpoint 0x{endpoint_addr:02x} not found, using fallback endpoint {endpt_desc:?}");
+            return Ok((iface_num, endpt_desc.address()));
         }
     }
 


### PR DESCRIPTION
Some CH57x macro keyboards use endpoint 0x02 for OUT transfers instead of the expected endpoint 0x04. Previously this required the `--endpoint-address 2` flag to work.

This change makes the endpoint detection more robust:
- If the preferred endpoint is found, behavior is identical to before
- If the preferred endpoint is not found on a HID interface, it falls back to any available interrupt OUT endpoint
- Non-HID interfaces are skipped early

This fixes auto-detection for devices like the 514c:8851 (3-key + 1 knob macropad) which uses endpoint 0x02, without breaking any existing devices.